### PR TITLE
Add lining.js to Text section

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ A continuously expanded list of framework/libraries and tools I used/want to use
 - [Plumin.js](http://www.pluminjs.com/) - Create and manipulate fonts using javascript
 - [Typeplate](http://typeplate.com/) - A 'typographic starter kit'
 - [slabText](https://github.com/freqdec/slabText) - jQuery plugin for producing big, bold & responsive headlines
+- [lining.js](https://github.com/zmmbreeze/lining.js) - A complete DOWN-TO-THE-LINE control for radical web typography
 
 ### Video
 - [medialementjs](http://mediaelementjs.com/) - Video and audio handling


### PR DESCRIPTION
Hello, I would like to add lining.js project to Text section. It makes line-by-line text styling easier: each line inside a block is placed into its own span of class `line`, and after that you can add style for each line using CSS selectors `:nth-of-type()`, `:nth-last-of-type()`, `:first-of-type()` etc.