### PR TITLE
Added the Marko templating engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ A continuously expanded list of framework/libraries and tools I used/want to use
 - [dotjs](https://olado.github.io/doT/) - Fast templating engine
 - [Handlebars](http://handlebarsjs.com/) - Minimal Templating on Steroids
 - [Hogan](http://twitter.github.io/hogan.js/) - JavaScript templating
+- [marko](http://markojs.com/) - Fast and lightweight HTML-based templating engine that compiles templates to CommonJS modules and supports streaming, async rendering, custom tags and a concise syntax
 - [mustache](https://github.com/janl/mustache.js) - Minimal templating with {{mustaches}} in JavaScript
 - [nunjucks](http://mozilla.github.io/nunjucks/) - A rich and powerful templating language
 - [paperclip.js](http://paperclipjs.com/) - Reactive DOM template engine built for speed and extensibility


### PR DESCRIPTION
Thanks for maintaining this list! Please consider adding [Marko](http://markojs.com/) to the "Templating" section.

Marko is a fast and lightweight HTML-based templating engine for Node.js as the browser. Template authors can use either a concise, indentation-based syntax or a familiar HTML syntax. It supports streaming and async rendering to create server-rendered pages that load instantly thanks to [progressive HTML rendering](http://knowthen.com/episode-8-serving-content-in-koajs-with-marko/). 

Marko has been shown to be one of the fastest templating engines with almost 2x the speed of Handlebars and 5x the speed of Jade and nunjucks:

| Template Engine | Results                      |
|-----------------|------------------------------|
| __marko__       | __187,729 op/s (fastest)__   |
| dot             | 183,161 op/s (2.43% slower)  |
| handlebars      | 104,634 op/s (44.26% slower) |
| dust            | 83,773 op/s (55.38% slower)  |
| swig            | 54,866 op/s (70.77% slower)  |
| jade            | 32,929 op/s (82.46% slower)  |
| nunjucks        | 32,306 op/s (82.79% slower)  |
| react           | 3,651 op/s (98.06% slower)   |

Source: [marko-js/templating-benchmarks](https://github.com/marko-js/templating-benchmarks)

Marko is heavily tested and battle-tested in production at eBay (and other companies). We also have an active Gitter chat room: https://gitter.im/marko-js/marko

[Marko Widgets](http://markojs.com/docs/marko-widgets/) is a separate UI component building library that uses Marko templates as the view. It offers advanced features like DOM diffing/patching, batched updates, stateful widgets, declarative event binding and efficient event delegation. Marko Widgets has been shown to be 10x faster than React for rendering the same page on the server using a very similar UI components-based architecture:

![Marko vs React](https://raw.githubusercontent.com/patrick-steele-idem/marko-vs-react/master/charts/requestsPerSecond.png)

Source: [Marko vs React](https://github.com/patrick-steele-idem/marko-vs-react)

Disclaimer: I'm the author of Marko and Marko Widgets