### PR TITLE
Add Lazy Progressive Enhancement to Lazy Loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,7 @@ A continuously expanded list of framework/libraries and tools I used/want to use
 ### Lazy Loading
 - [Aload](http://pazguille.github.io/aload/) - Asynchronously loads images, scripts, styles and more
 - [echo](http://toddmotto.com/labs/echo/) - Standalone lazy loading image micro-library
+- [Lazy Progressive Enhancement](http://tylerdeitz.co/lazy-progressive-enhancement/) - A lazy image loader designed to enforce progressive enhancement and valid HTML
 - [layzr.js](http://callmecavs.github.io/layzr.js/) - Dependency-free library for lazy loading images
 - [lazysizes](https://github.com/aFarkas/lazysizes) - fast and self-initializing lazyloader for images, iframes and more
 - [loadXT](https://github.com/ressio/lazy-load-xt) - Lazy loading for any elements


### PR DESCRIPTION
Most lazy loaders promote [invalid html](https://www.w3.org/TR/html5/embedded-content-0.html#attr-img-src) by omitting the `src` attribute, or aren't compatible for users without javascript.

Lazy Progressive Enhancement is designed to enforce progressive enhancement and valid html.

[Project website](http://tylerdeitz.co/lazy-progressive-enhancement/), [Github repository](https://github.com/tvler/lazy-progressive-enhancement/)